### PR TITLE
Add -Includes Parameter to Get-PnPList

### DIFF
--- a/Commands/Lists/GetList.cs
+++ b/Commands/Lists/GetList.cs
@@ -28,17 +28,83 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, name or Url (Lists/MyList) of the list.")]
         public ListPipeBind Identity;
 
+        [Parameter(Mandatory = false, ValueFromPipeline = false, Position = 1, HelpMessage = "Additional Properties to retrieve for the List item(s) to be returned")]
+        [ValidateSet("ContentTypes", "DataSource", "EventReceivers", "Fields", "SchemaXml")]
+        public string[] Includes;
+
         protected override void ExecuteCmdlet()
         {
             if (Identity != null)
             {
                 var list = Identity.GetList(SelectedWeb);
+
+                if (Includes.Length > 0)
+                {
+                    foreach (var include in Includes)
+                    {
+                        switch (include)
+                        {
+                            case "ContentTypes":
+                                ClientContext.Load(list, l => l.ContentTypes);
+                                break;
+                            case "DataSource":
+                                ClientContext.Load(list, l => l.DataSource);
+                                break;
+                            case "EventReceivers":
+                                ClientContext.Load(list, l => l.EventReceivers);
+                                break;
+                            case "Fields":
+                                ClientContext.Load(list, l => l.Fields);
+                                break;
+                            case "SchemaXml":
+                                ClientContext.Load(list, l => l.SchemaXml);
+                                break;
+                            default: break;
+                        }
+                    }
+                    ClientContext.ExecuteQueryRetry();
+                }
+
+
                 WriteObject(list);
 
             }
             else
             {
-                var lists = ClientContext.LoadQuery(SelectedWeb.Lists.IncludeWithDefaultProperties(l => l.Id, l => l.BaseTemplate, l => l.OnQuickLaunch, l => l.DefaultViewUrl, l => l.Title, l => l.Hidden, l => l.RootFolder.ServerRelativeUrl));
+
+                var query = (SelectedWeb.Lists.IncludeWithDefaultProperties(l => l.Id, l => l.BaseTemplate, l => l.OnQuickLaunch, l => l.DefaultViewUrl, l => l.Title, l => l.Hidden, l => l.RootFolder.ServerRelativeUrl));
+
+                //var lists = ClientContext.LoadQuery((SelectedWeb.Lists.IncludeWithDefaultProperties(l => l.Id, l => l.BaseTemplate, l => l.OnQuickLaunch, l => l.DefaultViewUrl, l => l.Title, l => l.Hidden, l => l.RootFolder.ServerRelativeUrl));
+
+                if (Includes.Length > 0)
+                {
+                    foreach (var include in Includes)
+                    {
+                        switch (include)
+                        {
+                            case "ContentTypes":
+                                query.Include(l => l.ContentTypes);
+                                break;
+                            case "DataSource":
+                                query.Include(l => l.DataSource);
+                                break;
+                            case "EventReceivers":
+                                query.Include(l => l.EventReceivers);
+
+                                break;
+                            case "Fields":
+                                query.Include(l => l.Fields);
+                                break;
+                            case "SchemaXml":
+                                query.Include(l => l.SchemaXml);
+
+                                break;
+                            default: break;
+                        }
+                    }
+                    ClientContext.ExecuteQueryRetry();
+                }
+                var lists = ClientContext.LoadQuery(query);
                 ClientContext.ExecuteQueryRetry();
                 WriteObject(lists, true);
             }

--- a/Commands/Lists/GetList.cs
+++ b/Commands/Lists/GetList.cs
@@ -2,6 +2,10 @@
 using Microsoft.SharePoint.Client;
 using SharePointPnP.PowerShell.CmdletHelpAttributes;
 using SharePointPnP.PowerShell.Commands.Base.PipeBinds;
+using System.Linq.Expressions;
+using System;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace SharePointPnP.PowerShell.Commands.Lists
 {
@@ -28,8 +32,8 @@ namespace SharePointPnP.PowerShell.Commands.Lists
         [Parameter(Mandatory = false, ValueFromPipeline = true, Position = 0, HelpMessage = "The ID, name or Url (Lists/MyList) of the list.")]
         public ListPipeBind Identity;
 
-        [Parameter(Mandatory = false, ValueFromPipeline = false, Position = 1, HelpMessage = "Additional Properties to retrieve for the List item(s) to be returned")]
-        [ValidateSet("ContentTypes", "DataSource", "EventReceivers", "Fields", "SchemaXml")]
+        [Parameter(Mandatory = false, ValueFromPipeline = false, Position = 1, HelpMessage = "Additional Properties to retrieve for the List item(s) to be returned")]  
+        [ValidateSet("AllowDeletion","BrowserFileHandling","ContentTypes","DataSource","DefaultDisplayFormUrl","DefaultEditFormUrl","DefaultNewFormUrl","DefaultViewPath","DocumentTemplateUrl","EffectiveBasePermissions","EffectiveBasePermissionsForUI","EnableAssignToEmail","EventReceivers","ExcludeFromOfflineClient","Fields","Forms","HasUniqueRoleAssignments","IsSiteAssetsLibrary","IsSystemList","ReadSecurity","RoleAssignments","SchemaXml","Tag","UserCustomActions","ValidationFormula","ValidationMessage","Views","WorkflowAssociations","WriteSecurity")]
         public string[] Includes;
 
         protected override void ExecuteCmdlet()
@@ -37,31 +41,14 @@ namespace SharePointPnP.PowerShell.Commands.Lists
             if (Identity != null)
             {
                 var list = Identity.GetList(SelectedWeb);
-
-                if (Includes.Length > 0)
+                if (Includes != null && Includes.Length > 0)
                 {
-                    foreach (var include in Includes)
-                    {
-                        switch (include)
-                        {
-                            case "ContentTypes":
-                                ClientContext.Load(list, l => l.ContentTypes);
-                                break;
-                            case "DataSource":
-                                ClientContext.Load(list, l => l.DataSource);
-                                break;
-                            case "EventReceivers":
-                                ClientContext.Load(list, l => l.EventReceivers);
-                                break;
-                            case "Fields":
-                                ClientContext.Load(list, l => l.Fields);
-                                break;
-                            case "SchemaXml":
-                                ClientContext.Load(list, l => l.SchemaXml);
-                                break;
-                            default: break;
-                        }
-                    }
+                    List<string> fields = new List<string>();
+                    fields.AddRange(Includes);
+                    List<Expression<Func<List, object>>> expressions = GetPropertyExpression<List>(fields);
+                    
+                    
+                    ClientContext.Load(list, expressions.ToArray());
                     ClientContext.ExecuteQueryRetry();
                 }
 
@@ -71,44 +58,60 @@ namespace SharePointPnP.PowerShell.Commands.Lists
             }
             else
             {
+                string [] defaultFields = { "Id", "BaseTemplate", "OnQuickLaunch", "DefaultViewUrl", "Title", "Hidden" };
 
-                var query = (SelectedWeb.Lists.IncludeWithDefaultProperties(l => l.Id, l => l.BaseTemplate, l => l.OnQuickLaunch, l => l.DefaultViewUrl, l => l.Title, l => l.Hidden, l => l.RootFolder.ServerRelativeUrl));
+                List<string> fields = new List<string>();
+                fields.AddRange(defaultFields);
 
-                //var lists = ClientContext.LoadQuery((SelectedWeb.Lists.IncludeWithDefaultProperties(l => l.Id, l => l.BaseTemplate, l => l.OnQuickLaunch, l => l.DefaultViewUrl, l => l.Title, l => l.Hidden, l => l.RootFolder.ServerRelativeUrl));
-
-                if (Includes.Length > 0)
+                if (Includes != null && Includes.Length > 0)
                 {
-                    foreach (var include in Includes)
-                    {
-                        switch (include)
-                        {
-                            case "ContentTypes":
-                                query.Include(l => l.ContentTypes);
-                                break;
-                            case "DataSource":
-                                query.Include(l => l.DataSource);
-                                break;
-                            case "EventReceivers":
-                                query.Include(l => l.EventReceivers);
-
-                                break;
-                            case "Fields":
-                                query.Include(l => l.Fields);
-                                break;
-                            case "SchemaXml":
-                                query.Include(l => l.SchemaXml);
-
-                                break;
-                            default: break;
-                        }
-                    }
-                    ClientContext.ExecuteQueryRetry();
+                    fields.AddRange(Includes);
+                  //  fields.Add("RootFolder.ServerRelativeUrl");
                 }
+                
+                List<Expression<Func<List, object>>> expressions = GetPropertyExpression<List>(fields);
+                
+                //Now handle that special case of  RootFolder.ServerRelativeUrl -- Should really do a check for "sub members and implement this recursively...
+                Expression<Func<List, object>> expressionRelativeUrl = l => l.RootFolder.ServerRelativeUrl;
+                expressions.Add(expressionRelativeUrl);
+
+                var query = (SelectedWeb.Lists.IncludeWithDefaultProperties(expressions.ToArray()));
+               
                 var lists = ClientContext.LoadQuery(query);
                 ClientContext.ExecuteQueryRetry();
                 WriteObject(lists, true);
             }
         }
+
+        private static List<Expression<Func<T, object>>> GetPropertyExpression<T>(List<string> Includes)
+        {
+            var type = typeof(T);
+            var expressions = new List<Expression<Func<T, object>>>();
+
+            var properties = type.GetProperties();
+
+            foreach(var Include in Includes)
+            {
+                //Add . checking for nested includes.. then it would call this T function recursively suing the type of the property
+                // example RootFolder.ServerRelativeUrl GetPropertyExpression<Folder>(new string [] { "ServerRelativeUrl" }
+                var sanityCheck = (from property in properties where property.Name == Include select property).FirstOrDefault();
+                if(sanityCheck != null)
+                {
+                    //the property exists in the parent type.
+
+                    ParameterExpression paramExpression = Expression.Parameter(type, "l");
+                    MemberExpression propertyExpression = Expression.Property(paramExpression, Include);
+                    var bodyExpression = Expression.Convert(propertyExpression, typeof(Object));
+                    //MemberExpression propertyExpression = Expression.Property(instance,  Include);
+                    var expression = System.Linq.Expressions.ParameterExpression.Lambda<Func<T, object>>(bodyExpression, new[] { paramExpression });
+                    expressions.Add(expression);
+                }
+            }
+
+            return expressions;
+        }
+
+
     }
 
 }

--- a/Documentation/AddPnPPublishingPage.md
+++ b/Documentation/AddPnPPublishingPage.md
@@ -4,6 +4,7 @@ Adds a publishing page
 ```powershell
 Add-PnPPublishingPage [-Title <String>]
                       -PageName <String>
+                      -FolderPath <String>
                       -PageTemplateName <String>
                       [-Publish [<SwitchParameter>]]
                       [-Web <WebPipeBind>]
@@ -13,6 +14,7 @@ Add-PnPPublishingPage [-Title <String>]
 ##Parameters
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
+|FolderPath|String|True|The site relative folder path of the page to be added|
 |PageName|String|True|The name of the page to be added as an aspx file|
 |PageTemplateName|String|True|The name of the page layout you want to use. Specify without the .aspx extension. So 'ArticleLeft' or 'BlankWebPartPage'|
 |Publish|SwitchParameter|False|Publishes the page. Also Approves it if moderation is enabled on the Pages library.|
@@ -25,3 +27,9 @@ Parameter|Type|Required|Description
 PS:> Add-PnPPublishingPage -PageName 'OurNewPage' -Title 'Our new page' -PageTemplateName 'ArticleLeft'
 ```
 Creates a new page based on the pagelayout 'ArticleLeft'
+
+###Example 2
+```powershell
+PS:> Add-PnPPublishingPage -PageName 'OurNewPage' -Title 'Our new page' -PageTemplateName 'ArticleLeft' -Folder '/Pages/folder'
+```
+Creates a new page based on the pagelayout 'ArticleLeft' with a site relative folder path

--- a/Documentation/AddPnPPublishingPage.md
+++ b/Documentation/AddPnPPublishingPage.md
@@ -4,7 +4,6 @@ Adds a publishing page
 ```powershell
 Add-PnPPublishingPage [-Title <String>]
                       -PageName <String>
-                      -FolderPath <String>
                       -PageTemplateName <String>
                       [-Publish [<SwitchParameter>]]
                       [-Web <WebPipeBind>]
@@ -14,7 +13,6 @@ Add-PnPPublishingPage [-Title <String>]
 ##Parameters
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
-|FolderPath|String|True|The site relative folder path of the page to be added|
 |PageName|String|True|The name of the page to be added as an aspx file|
 |PageTemplateName|String|True|The name of the page layout you want to use. Specify without the .aspx extension. So 'ArticleLeft' or 'BlankWebPartPage'|
 |Publish|SwitchParameter|False|Publishes the page. Also Approves it if moderation is enabled on the Pages library.|
@@ -27,9 +25,3 @@ Parameter|Type|Required|Description
 PS:> Add-PnPPublishingPage -PageName 'OurNewPage' -Title 'Our new page' -PageTemplateName 'ArticleLeft'
 ```
 Creates a new page based on the pagelayout 'ArticleLeft'
-
-###Example 2
-```powershell
-PS:> Add-PnPPublishingPage -PageName 'OurNewPage' -Title 'Our new page' -PageTemplateName 'ArticleLeft' -Folder '/Pages/folder'
-```
-Creates a new page based on the pagelayout 'ArticleLeft' with a site relative folder path

--- a/Documentation/GetPnPList.md
+++ b/Documentation/GetPnPList.md
@@ -4,6 +4,7 @@ Returns a List object
 ```powershell
 Get-PnPList [-Web <WebPipeBind>]
             [-Identity <ListPipeBind>]
+            [-Includes <String[]>]
 ```
 
 
@@ -14,6 +15,7 @@ Get-PnPList [-Web <WebPipeBind>]
 Parameter|Type|Required|Description
 ---------|----|--------|-----------
 |Identity|ListPipeBind|False|The ID, name or Url (Lists/MyList) of the list.|
+|Includes|String[]|False|Additional Properties to retrieve for the List item(s) to be returned|
 |Web|WebPipeBind|False|The web to apply the command to. Omit this parameter to use the current web.|
 ##Examples
 


### PR DESCRIPTION
Adds an -Include parameter enabling user to specifiy additional properties to pull back from the list. Will automatically generate the query. 

If this looks good, and is an acceptable pattern there are a few other places I would like to implement Get-PnPSite, Get-PnPWeb.

